### PR TITLE
Establish NextSnapMail project identity and scope

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,54 @@
+# Credits and project history
+
+NextSnapMail exists because of the work contributed to SnappyMail, RainLoop,
+their dependencies, and the Nextcloud integration over many years. Renaming the
+fork does not remove or replace that history.
+
+## NextSnapMail
+
+NextSnapMail is an independent community fork focused on maintaining the
+webmail client as a Nextcloud app. Development under the NextSnapMail name began
+on 2026-06-18 in the
+[oe79/NextSnapMail](https://github.com/oe79/NextSnapMail) repository.
+
+Copyright for new modifications belongs to the respective NextSnapMail
+contributors.
+
+## SnappyMail
+
+NextSnapMail is derived from
+[SnappyMail](https://github.com/the-djmaze/snappymail), a modernized and
+security-focused fork of RainLoop Webmail Community Edition.
+
+- Copyright (c) 2020 - 2024 SnappyMail
+- Original project lead: DJ Maze (`the-djmaze`)
+- Original project website: <https://snappymail.eu/>
+
+The complete contributor history remains available in the Git history inherited
+by this fork.
+
+## RainLoop
+
+SnappyMail and therefore NextSnapMail are derived from RainLoop Webmail
+Community Edition.
+
+- Copyright (c) 2013 - 2022 RainLoop
+- Original community repository:
+  <https://github.com/RainLoop/rainloop-webmail>
+
+## Nextcloud integration
+
+The inherited Nextcloud integration acknowledges the RainLoop and SnappyMail
+teams and contributors including Pierre-Alain Bandinelli, Tab Fitts,
+Nextgen Networks, translators, testers, and all other contributors represented
+in the repository history.
+
+## Third-party software
+
+The repository includes third-party libraries, themes, translations, and other
+components with their own copyright and license notices. Their inclusion here
+does not change those notices or licenses. A dedicated third-party license audit
+is required before the first NextSnapMail release.
+
+The authoritative attribution record is the source files, included license
+documents, and Git history. This summary is not intended to replace them.

--- a/README.md
+++ b/README.md
@@ -1,226 +1,100 @@
-<div align="center">
-  <a href="https://github.com/the-djmaze/snappymail">
-    <img src="https://snappymail.eu/static/img/logo-256x256-white.png">
-  </a>
-  <br>
-  <h1>SnappyMail</h1>
-  <br>
+# NextSnapMail
 
-[![github-actions](https://github.com/the-djmaze/snappymail/actions/workflows/docker.yml/badge.svg)](https://github.com/the-djmaze/snappymail/actions/workflows/docker.yml)
-[![docker-image-size](https://img.shields.io/docker/image-size/djmaze/snappymail/latest)](https://hub.docker.com/r/djmaze/snappymail/tags)
+NextSnapMail is an independent community fork of
+[SnappyMail](https://github.com/the-djmaze/snappymail), focused exclusively on
+providing and maintaining the webmail client as an app for
+[Nextcloud](https://nextcloud.com/).
 
-  <p>
-    Simple, modern, lightweight &amp; fast web-based email client.
-  </p>
-  <p>
-    The drastically upgraded &amp; secured fork of <a href="https://github.com/RainLoop/rainloop-webmail">RainLoop Webmail Community edition</a>.
-  </p>
-  <p>
-    We thank the RainLoop Team for making a great PHP 5 product that was good in the past.
-  </p>
-  <p>
-    Up to date system requirements, snappy performance, simple installation and upgrade, no database required
-    - all these make SnappyMail a good choice.
-  </p>
-  <h2></h2>
-  <br>
-</div>
+The project continues development of the existing SnappyMail codebase for the
+Nextcloud use case. It is not an official continuation of SnappyMail and is not
+affiliated with, endorsed by, or sponsored by Nextcloud GmbH.
 
-For more information about the product, check [snappymail.eu](https://snappymail.eu/).
+## Project status
 
-Information about installing the product, check the [wiki page](https://github.com/the-djmaze/snappymail/wiki/Installation-instructions).
+NextSnapMail is currently in the initial restructuring phase and is **not yet
+ready for production use**.
 
-And don't forget to read the whole [Wiki](https://github.com/the-djmaze/snappymail/wiki).
+The repository still contains the original SnappyMail application structure,
+name, app identifier, integrations, and release tooling. These will be reviewed
+and migrated incrementally. Until a first NextSnapMail release is published,
+use the official SnappyMail releases for existing installations.
+
+## Scope
+
+NextSnapMail intends to maintain:
+
+- the SnappyMail webmail core required by the Nextcloud app;
+- integration with current supported Nextcloud releases;
+- IMAP, SMTP, Sieve, contacts, calendar, and file integration used through
+  Nextcloud;
+- a self-contained Nextcloud app package and release process;
+- security, compatibility, accessibility, and localization fixes.
+
+The project does not intend to publish or maintain separate distributions for:
+
+- Docker or standalone container images;
+- ownCloud;
+- Cloudron, cPanel, CyberPanel, HestiaCP, Virtualmin, or similar hosting panels;
+- Debian, Arch Linux, or other system packages;
+- standalone SnappyMail installations outside Nextcloud.
+
+This scope describes the direction of the project. Files for unsupported
+targets remain in the repository during the initial migration and will only be
+removed after their dependencies have been reviewed.
+
+## Planned first milestones
+
+1. Establish the NextSnapMail project identity and preserve provenance.
+2. Decide and document the new Nextcloud app identifier and migration path.
+3. Bundle the required Nextcloud integration without relying on the former
+   SnappyMail package service.
+4. Introduce a reproducible Nextcloud-only build and test process.
+5. Modernize the integration for supported Nextcloud and PHP versions.
+6. Publish signed, source-backed Nextcloud app releases.
+
+## Contributing
+
+The contribution workflow and compatibility targets are still being prepared.
+Bug reports and changes should be submitted to the
+[NextSnapMail repository](https://github.com/oe79/NextSnapMail).
+
+Please avoid large mechanical renames of the internal `RainLoop` and
+`SnappyMail` namespaces. They are part of the inherited architecture and will
+be migrated only where doing so is technically justified.
+
+## Provenance and modifications
+
+NextSnapMail is based on SnappyMail, which is itself a fork of RainLoop Webmail
+Community Edition.
+
+The NextSnapMail project began modifying and restructuring the codebase on
+2026-06-18. A summary of inherited projects and contributors is maintained in
+[CREDITS.md](CREDITS.md). Project changes are recorded in Git history and will
+be documented in release notes.
+
+Copyright notices from SnappyMail, RainLoop, and bundled third-party components
+must remain intact:
+
+- Copyright (c) 2020 - 2024 SnappyMail
+- Copyright (c) 2013 - 2022 RainLoop
+- Copyright for NextSnapMail modifications belongs to their respective
+  contributors
 
 ## License
 
-**SnappyMail** is released under
-**GNU AFFERO GENERAL PUBLIC LICENSE Version 3 (AGPL)**.
-http://www.gnu.org/licenses/agpl-3.0.html
+This project remains licensed under the **GNU Affero General Public License,
+version 3 (AGPLv3)**. See [LICENSE](LICENSE) for the complete terms.
 
-Copyright (c) 2020 - 2024 SnappyMail
-Copyright (c) 2013 - 2022 RainLoop
+Modified versions must retain applicable notices, identify modifications, and
+remain available under the AGPL. Users interacting with a modified version over
+a network must be offered access to its corresponding source code as required
+by section 13 of the AGPLv3.
 
-## Modifications
+Bundled third-party components may carry additional compatible license and
+copyright notices. Those notices remain applicable to their respective files.
 
-This fork of RainLoop has the following changes:
+## Trademarks
 
-* Privacy/GDPR friendly (no: Social, Gravatar, Facebook, Google, Twitter, DropBox, X-Mailer)
-* Admin uses password_hash/password_verify
-* Auth failed attempts written to syslog
-* Added Fail2ban instructions
-* ES2020
-* PHP 7.4+ required
-* PHP mbstring extension required
-* PHP replaced pclZip with PharData and ZipArchive
-* Dark mode
-* Added option to remove background/font colors from messages for real "dark mode"
-* Removed BackwardCapability (class \RainLoop\Account)
-* Removed ChangePassword (re-implemented as plugin)
-* Removed POP3 support
-* Removed background video support
-* Removed Sentry (Application Monitoring and Error Tracking Software)
-* Removed Spyc yaml
-* Removed OwnCloud
-* Replaced gulp-uglify with gulp-terser
-* CRLF => LF line endings
-* Embed boot.js and boot.css into index.html
-* Removal of old JavaScript code (things are native these days)
-* Added modified [Squire](https://github.com/the-djmaze/Squire/tree/snappymail) HTML editor as replacement for CKEditor
-* Updated [Sabre/VObject](https://github.com/sabre-io/vobject)
-* Split Admin specific JavaScript code from User code
-* Split Sieve specific JavaScript code from User code
-* JSON reviver
-* Better memory garbage collection management
-* Added serviceworker for Notifications
-* Added advanced Sieve scripts editor
-* Slimmed down language files
-* Replaced webpack with rollup
-* No user-agent detection (use device width)
-* Added support to load plugins as .phar
-* Replaced old Sabre library
-* AddressBook Contacts support MySQL/MariaDB utf8mb4
-* Added [Fetch Metadata Request Headers](https://www.w3.org/TR/fetch-metadata/) checks
-* Reduced excessive DOM size
-* Support [Kolab groupware](https://kolab.org/)
-* Support many more [IMAP RFC's](https://snappymail.eu/comparison#IMAP)
-* Support Sodium and OpenSSL for encryption
-* Much better PGP support
-
-
-### Supported browsers
-
-This fork uses downsized/simplified versions of scripts and has no support for Internet Explorer nor Edge Legacy.
-Supported are:
-
-* Chrome 80+
-* Edge 80+
-* Firefox 78+
-* Opera 67+
-* Safari 13.1+
-
-
-### Removal of old JavaScript
-
-The result is faster and smaller download code (good for mobile networks).
-
-* Added dev/prototype.js for some additional features
-* Modified Jua.js to be without jQuery
-* Replaced Autolinker with simple https/email detection
-* Replaced momentToNode with proper HTML5 `<time>`
-* Replaced resize listeners with ResizeObserver
-* Replaced bootstrap.js with native drop-in replacement
-* Replaced dev/Common/ClientStorageDriver/* with Web Storage Objects polyfill
-* Replaced *Ajax with *Fetch classes because we use the Fetch API, not jQuery.ajax
-* Replaced [knockoutjs](https://github.com/knockout/knockout) 3.4 with a modified 3.5.1
-* Replaced knockout-sortable with native HTML5 drag&drop
-* Replaced simplestatemanager with CSS @media
-* Replaced inputosaurus with own code
-* Replaced keymaster with own shortcuts handler
-* Replaced OpenPGP.js v2 with OpenPGP.js v5
-* Removed ifvisible.js
-* Removed pikaday
-* Removed underscore
-* Removed polyfills
-* Removed Modernizr
-* Removed nanoscroll
-* Removed lightgallery
-* Removed jQuery
-* Removed jquery-ui
-* Removed jquery-scrollstop
-* Removed jquery-mousewheel
-* Removed matchmedia-polyfill
-* Removed momentjs (use Intl)
-* Removed opentip (use CSS)
-* Removed non-community (aka Prem/Premium/License) code
-* Removed ProgressJS
-
-
-RainLoop 1.17 vs SnappyMail
-
-|js/*           	|RainLoop 	|Snappy   	|
-|---------------	|--------:	|--------:	|
-|admin.js        	|2.170.153	|   84.925	|
-|app.js          	|4.207.787	|  447.263	|
-|boot.js         	|  868.735	|    4.343	|
-|libs.js         	|  658.812	|  233.728	|
-|sieve.js         	|        0	|   91.418	|
-|polyfills.js    	|  334.608	|        0	|
-|serviceworker.js	|        0	|      285	|
-|TOTAL           	|8.240.095	|  861.962	|
-
-|js/min/*       	|RainLoop 	|Snappy   	|RL gzip	|SM gzip	|RL brotli	|SM brotli	|
-|---------------	|--------:	|--------:	|------:	|------:	|--------:	|--------:	|
-|admin.min.js    	|  256.831	|   41.719	| 73.606	| 14.022	| 60.877  	| 12.567	|
-|app.min.js      	|  515.367	|  202.101	|139.456	| 68.505	|110.485  	| 58.481	|
-|boot.min.js     	|   84.659	|    2.231	| 26.998	|  1.271	| 23.643  	|  1.067	|
-|libs.min.js     	|  584.772	|  110.646	|180.901	| 39.518	|155.182  	| 35.207	|
-|sieve.min.js     	|        0	|   45.504	|      0	| 11.131	|      0  	|  9.917	|
-|polyfills.min.js	|   32.837	|        0	| 11.406	|      0	| 10.175  	|      0	|
-|TOTAL user      	|1.217.635	|  314.978	|358.761	|109.294	|299.485  	| 94.755	|
-|TOTAL user+sieve	|1.217.635	|  360.482	|358.761	|120.425	|299.485  	|104.672	|
-|TOTAL admin     	|  959.099	|  154.596	|292.911	| 54.811	|249.877  	| 48.841	|
-
-For a user it is around 66% smaller and faster than traditional RainLoop.
-
-### CSS changes
-
-* Solve jQuery removed "features" with native css code
-* Themes work in mobile mode
-* Bugfix invalid/conflicting css rules
-* Use flexbox
-* Use border-box
-* Split app.css to have separate admin.css
-* Remove oldschool 'float'
-* Remove unused css
-* Removed html.no-css
-* Removed dev/Styles/Cmd.less
-* Removed dev/Styles/Scroll.less
-* Removed Internet Explorer from normalize.css
-* Removed node_modules/opentip/css/opentip.css
-* Removed node_modules/pikaday/css/pikaday.css
-* Removed unused vendors/bootstrap/less/*
-* Removed vendors/jquery-nanoscroller/nanoscroller.css
-* Removed vendors/jquery-letterfx/jquery-letterfx.min.css
-* Removed vendors/Progress.js/minified/progressjs.min.css
-* Removed gulp-autoprefixer
-
-
-|css/*       	|RainLoop	|Snappy   	|RL gzip	|SM gzip	|SM brotli	|
-|------------	|-------:	|------:	|------:	|------:	|--------:	|
-|app.css     	| 340.331	| 85.073	| 46.946	| 17.792	| 15.210	|
-|app.min.css 	| 274.947	| 68.272	| 39.647	| 15.615	| 13.636	|
-|boot.css    	|       	|  1.326	|       	|    664	|    545	|
-|boot.min.css	|       	|  1.071	|       	|    590	|    474	|
-|admin.css    	|       	| 30.880	|       	|  7.045	|  6.127	|
-|admin.min.css	|       	| 24.959	|       	|  6.368	|  5.615	|
-
-### PGP
-RainLoop uses the old OpenPGP.js v2
-SnappyMail v2.12 uses OpenPGP.js v5, GnuPG and Mailvelope.
-SnappyMail is able to use and generate ECDSA and EDDSA keys, where RainLoop does not.
-
-Since SnappyMail tries to achieve the best mobile experience, it forked OpenPGP.js to strip it down.
-* remove all unused Node.js
-* remove all old browsers support
-See https://github.com/the-djmaze/openpgpjs for development
-
-|OpenPGP        	|RainLoop 	|Snappy   	|RL gzip	|SM gzip	|RL brotli	|SM brotli	|
-|---------------	|--------:	|--------:	|------:	|-------:	|--------:	|--------:	|
-|openpgp.min.js 	|  330.742	|  546.165	|102.388	| 169.207	| 84.241  	|  138.688	|
-|openpgp.worker 	|    1.499	|         	|    824	|        	|    695 	|        	|
-
-
-### Squire vs CKEditor
-The [Squire](https://github.com/neilj/Squire) implementation is not 100% compatible yet, but it shows the massive overhead of CKEditor.
-
-Still TODO:
-
-* support for tables (really needed?!?)
-
-|       	| normal	| min    	| gzip  	| min gzip	|
-|--------	|-------:	|-------:	|------:	|--------:	|
-|squire  	| 122.321	|  41.906	| 31.867	|   14.330	|
-|ckeditor	|       ?	| 520.035	|      ?	|  155.916	|
-
-CKEditor including the 7 asset requests (css,language,plugins,icons) is 633.46 KB / 180.47 KB (gzip).
+NextSnapMail is an independent project. “Nextcloud” and the Nextcloud logo are
+trademarks of Nextcloud GmbH. The Nextcloud name is used only to describe
+compatibility and the intended platform. See [TRADEMARKS.md](TRADEMARKS.md).

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,22 @@
+# Trademark notice
+
+NextSnapMail is an independent community project. It is not affiliated with,
+endorsed by, or sponsored by Nextcloud GmbH, the SnappyMail project, or the
+RainLoop project.
+
+“Nextcloud” and the Nextcloud logo are trademarks of Nextcloud GmbH. This
+repository uses the word “Nextcloud” only as a compatibility reference and to
+identify the platform for which NextSnapMail is developed. NextSnapMail does not
+use the Nextcloud name as its application name and must not use the Nextcloud
+logo as its own logo.
+
+SnappyMail, RainLoop, and other names or logos referenced in this repository may
+be trademarks of their respective owners. Their use identifies the projects
+from which code or functionality originated and does not imply endorsement.
+
+Contributors should avoid branding, screenshots, domains, or descriptions that
+could cause users to believe NextSnapMail is an official Nextcloud, SnappyMail,
+or RainLoop product.
+
+The current Nextcloud trademark guidelines are available at
+<https://nextcloud.com/trademarks/>.


### PR DESCRIPTION
## Summary
- rebrand the project documentation as NextSnapMail
- define the Nextcloud-only maintenance scope and initial milestones
- preserve SnappyMail and RainLoop provenance and copyright notices
- add independent-project and trademark guidance

## Notes
- application code, app ID, namespaces, and release tooling remain unchanged
- the existing AGPLv3 license file remains unchanged

## Verification
- documentation formatting checked with git diff --check
- local documentation links verified