### PR TITLE
Preserve saved credentials during mail outages

### DIFF
--- a/integrations/nextcloud/snappymail/lib/Util/SnappyMailHelper.php
+++ b/integrations/nextcloud/snappymail/lib/Util/SnappyMailHelper.php
@@ -99,11 +99,20 @@ class SnappyMailHelper
 							$oActions->SetSignMeToken($oAccount);
 						}
 					} catch (\Throwable $e) {
-						// Login failure, reset password to prevent more attempts
 						if (!$isOIDC) {
-							$sUID = \OC::$server->get(\OCP\IUserSession::class)->getUser()->getUID();
-							\OC::$server->get(\OCP\ISession::class)->set('snappymail-passphrase', '');
-							\OC::$server->get(\OCP\IConfig::class)->setUserValue($sUID, 'snappymail', 'passphrase', '');
+							// Credentials saved in the user's personal settings must never be
+							// deleted as a side effect of a failed login. A temporary network,
+							// DNS, TLS, or mail server outage is not a password change.
+							//
+							// Only discard the password captured from the current Nextcloud
+							// session when the IMAP server explicitly rejected authentication.
+							// Persisted credentials remain available for the user to inspect or
+							// replace in their personal settings.
+							if ($e instanceof \RainLoop\Exceptions\ClientException
+							 && \RainLoop\Notifications::AuthError === $e->getCode()
+							) {
+								\OC::$server->get(\OCP\ISession::class)->set('snappymail-passphrase', '');
+							}
 							\SnappyMail\Log::error('Nextcloud', $e->getMessage());
 						}
 					}


### PR DESCRIPTION
## Summary
- keep credentials saved in Nextcloud personal settings when automatic IMAP login fails
- preserve the Nextcloud session password during network, DNS, TLS, and mail-server outages
- clear only the temporary session password when IMAP explicitly reports an authentication error
- never erase the persisted personal-settings passphrase as a login side effect

## Verification
- manually A/B tested on two Nextcloud instances
- patched instance automatically regained access after the mail server became available
- unpatched instance reproduced the old behavior and required entering the password again
- PHP lint runs automatically for PHP 8.2 through 8.5