### PR TITLE
Prepare app store metadata

### DIFF
--- a/integrations/nextcloud/nextsnapmail/README.md
+++ b/integrations/nextcloud/nextsnapmail/README.md
@@ -1,6 +1,11 @@
-# nextsnapmail-nextcloud
+# NextSnapMail for Nextcloud
 
-nextsnapmail-nextcloud is a plugin for Nextcloud to use the excellent NextSnapMail Webmail (https://snappymail.eu/).
+NextSnapMail is an independent community fork of SnappyMail focused on
+integration with Nextcloud. It provides the inherited SnappyMail webmail client
+as a self-contained Nextcloud app.
+
+NextSnapMail is not affiliated with, endorsed by, or sponsored by Nextcloud
+GmbH. It is not an official Nextcloud app.
 
 Thank you to all contributors to SnappyMail for nextcloud:
 - RainLoop Team, who initiated it
@@ -9,24 +14,26 @@ Thank you to all contributors to SnappyMail for nextcloud:
 - Nextgen Networks (@nextgen-networks)
 - [All testers of issue 96](https://github.com/the-djmaze/snappymail/issues/96)
 
-## How to Install
+## How to install
 
-Start within Nextcloud as user with administrator rights and click on the "+ Apps" button in the upper-right corner dropdown menu:
+Install and enable the `nextsnapmail` app through the Nextcloud app management
+interface or by deploying a signed NextSnapMail release archive.
 
-![Image1](https://raw.githubusercontent.com/the-djmaze/snappymail/master/integrations/nextcloud/screenshots/help_a1.png)
+After enabling the app, open the Nextcloud administration settings and go to
+the dedicated "NextSnapMail" section. From there, open the NextSnapMail admin
+panel and configure the instance-wide mail domains and login behaviour.
 
-Then, enable the SnappyMail plugin that you will find in the "Social & communication" section:
+To enter the NextSnapMail admin area, you must be a Nextcloud administrator
+or use the generated NextSnapMail admin credentials. The default login is
+`admin` and the generated password is stored in
+`[nextcloud-data]/appdata_nextsnapmail/_data_/_default_/admin_password.txt`.
+Change this password after the first login.
 
-![Image2](https://raw.githubusercontent.com/the-djmaze/snappymail/master/integrations/nextcloud/screenshots/help_a2.png)
-
-After a quick wait, SnappyMail is installed. Now you should configure it before use: open the Nextcloud admin panel (upper-right corner dropdown menu -> Settings) and go to "Additional settings" under the "Administration" section. There, click on the "Go to NextSnapMail Webmail admin panel" link.
-
-![Image3](https://raw.githubusercontent.com/the-djmaze/snappymail/master/integrations/nextcloud/screenshots/nextcloud-admin.png)
-
-To enter SnappyMail admin area, you must be Nextcloud admin (so you get logged in automatically) or else use the admin login credentials.
-The default login is "admin" and the default password will be generated in `[nextcloud-data]/app_nextsnapmail/_data_/_default_/admin_password.txt`. Don't forget to change it once in the admin panel!
-
-From that point, all instance-wide SnappyMail settings can be tweaked as you wish. One important point is the "Domains" section where you should set up the IMAP/SMTP parameters that will be associated with the email adresses of your users. Basically, if a user of the Nextcloud instance starts SnappyMail and puts "firstname@domain.tld" as an email address, then SnappyMail should know how to connect to the IMAP & SMTP of domain.tld. You can fill in this information in the "Domains" section of the SnappyMail admin settings. For more information how to configure an automatic login for your Nextcloud users see [How to auto-connect to SnappyMail?](#how-to-auto-connect-to-snappymail)
+From that point, all instance-wide NextSnapMail settings can be configured.
+One important point is the "Domains" section where you set up the IMAP/SMTP
+parameters associated with the email addresses of your users. For example, if
+a user signs in with `firstname@example.com`, NextSnapMail must know how to
+connect to the IMAP and SMTP services for `example.com`.
 
 ![grafik](https://user-images.githubusercontent.com/63400209/199767908-fbef0f50-ecb7-47ae-9ac1-771959d4b7f5.png)
 
@@ -36,19 +43,23 @@ From that point, all instance-wide SnappyMail settings can be tweaked as you wis
 ### Contacts
 SnappyMail automatically connects with the Nextcloud contacts app. Download and install the [contacts app](https://apps.nextcloud.com/apps/contacts) for SnappyMail to obtain access to all registered users on the Nextcloud system, as well as users' personal contacts saved in here.
 
-## SnappyMail Settings, Where Are They?
+## NextSnapMail settings
 
-SnappyMail for Nextcloud is highly configurable. But settings are available in multiple places and this can be misleading for first-time users.
+NextSnapMail has both administrator settings and user settings.
 
-### SnappyMail admin settings
-NextSnapMail admin settings can be reached only by the Nextcloud administrator. Open the Nextcloud admin panel ("Admin" in the upper-right corner dropdown menu) and go to "Additionnal settings". There, click on the "Go to NextSnapMail Webmail admin panel" link. Alternatively, you may use the following link: https://path.to.nextcloud/index.php/apps/nextsnapmail/?admin.
+### Administrator settings
 
-SnappyMail admin settings include all settings that will apply to all SnappyMail users (default login rules, branding, management of plugins, security rules and domains).
+NextSnapMail administrator settings are available to Nextcloud administrators
+in the dedicated "NextSnapMail" section of the Nextcloud administration
+settings. The linked NextSnapMail admin panel contains settings that apply to
+all users, including domains, login rules, branding, extensions, and security
+rules.
 
-### SnappyMail user settings
-Each user of SnappyMail can also change user-specific behaviors in the SnappyMail user settings. SnappyMail user settings are found within SnappyMail by clicking on the user button (in the upper-right corner of SnappyMail) and then choosing "Settings" in the dropdown menu.
+### User settings
 
-SnappyMail user settings include management of contacts, of email accounts, of folders, appearance and OpenPGP.
+Each user can configure user-specific behaviour inside NextSnapMail by opening
+the user menu and choosing "Settings". Users can manage contacts, mail
+accounts, folders, appearance, OpenPGP, and related settings there.
 
 ### The specificity of SnappyMail user accounts
 The plugin passes the login information of the user to the SnappyMail app which then creates and manages the user accounts. Accounts in SnappyMail are based soley on the authenticated email accounts, and do not take into account the nextcloud user which created them in the first place. If two or more Nextcloud users have the same email account in additional settings, they will in fact share the same 'email account' in SnappyMail including any additional email accounts that they may have added subsequently to their main account.
@@ -63,20 +74,20 @@ Example: if the username `john` is passed to SnappyMail, the "default domain" `e
 You can configure the "default domain" and connected settings in the SnappyMail Admin Panel under the menu "Login".
 
 ### Auto-connect options
-The Nextcloud administrator can choose how SnappyMail tries to automatically login when a user clicks on the icon of SnappyMail within Nextcloud. There are different options that can be found in the Nextcloud "Settings -> Administration -> Additional settings":
+The Nextcloud administrator can choose how NextSnapMail tries to automatically login when a user clicks on the NextSnapMail app icon. These options are available in the dedicated NextSnapMail section of the Nextcloud administration settings:
 
 #### Option 1: Users will login manually, or define credentials in their personal settings for automatic logins.
-If the user sets his credentials for the mailbox in his personal account under "Settings -> Additional settings", these credentials are used by SnappyMail to login.
+If the user sets mailbox credentials in the dedicated NextSnapMail section of their personal settings, these credentials are used by NextSnapMail to login.
 If no personal credentials are defined the user is prompted by SnappyMail to insert his credentials every time he tries to open the SnappyMail App within Nextcloud.
 
 #### Option 2: Attempt to automatically login users with their Nextcloud username and password, or user-defined credentials, if set.
-If the user sets his credentials for the mailbox in his personal account under "Settings -> Additional settings", these credentials are used by SnappyMail to login.
+If the user sets mailbox credentials in the dedicated NextSnapMail section of their personal settings, these credentials are used by NextSnapMail to login.
 If no personal credentials are defined the Nextcloud username and password is used by SnappyMail to login (eventually adding the [default domain](#default-domain)).
 
 If your IMAP server only accepts usernames without a domain (for example the ldap username of your user) the automatic addition of the "default domain" would block your users from logging in to your IMAP server - but on the other side it is needed by SnappyMail to determine the server settings to use. In such a case you must configure SnappyMail to strip off the domain part before sending the credentials to your IMAP server. This is done by entering to the SnappyMail Admin Panel -> Domains -> clicking on your default domain -> flagging the checkbox "Use short login" under IMAP and SMTP.
 
 #### Option 3: Attempt to automatically login users with their Nextcloud email and password, or user-defined credentials, if set.
-If the user sets his credentials for the mailbox in his personal account under "Settings -> Additional settings", these credentials are used by SnappyMail to login.
+If the user sets mailbox credentials in the dedicated NextSnapMail section of their personal settings, these credentials are used by NextSnapMail to login.
 If no personal credentials are defined the mail address of the Nextcloud user and his password are used by SnappyMail to login. SnappyMail will lookup the "Domain" settings for a configuration that meets the domain part of the mail address passed as username.
 
 #### Option 4: Attempt to automatically login with OIDC when active
@@ -89,7 +100,9 @@ Beware, if you tick this box, all Nextcloud users will *not* be able to use the 
 ### Auto-connection for one user at a time
 Except if the above setting is activated, any Nextcloud user can have Nextcloud and SnappyMail keep in mind the default email/password to connect to SnappyMail. There, logging in Nextcloud is sufficient to then access SnappyMail within Nextcloud.
 
-To fill in the default email address and password to use, each Nextcloud user should go in the personal settings: choose "Settings" in the upper-right corner dropdown menu. Under "Personal" select the "Additional settings" section where you can find the "NextSnapMail Webmail" settings. You can also use this direct link: https://path.to.nextcloud/settings/user/additional.
+To fill in the default email address and password to use, each Nextcloud user
+can open their personal settings and select the dedicated "NextSnapMail"
+section.
 
 
 ## How to Activate SnappyMail Logging and then Find Logs

--- a/integrations/nextcloud/nextsnapmail/appinfo/info.xml
+++ b/integrations/nextcloud/nextsnapmail/appinfo/info.xml
@@ -25,21 +25,22 @@ use case. It is not affiliated with, endorsed by, or sponsored by Nextcloud GmbH
 - **Many security features** (Sodium encrypted passwords, Sec-Fetch, TOTP 2FA, DKIM, prevent tracking, etc.)
 - **Kolab integrations**
 
-After enabling in Nextcloud, go to Nextcloud admin panel, "Additional settings" and you will see a "NextSnapMail Webmail" section.
-There, click on the link to go to the NextSnapMail admin panel.
+After enabling the app, administrators can configure the integration in the
+dedicated "NextSnapMail" section of the Nextcloud administration settings.
+Users can add their initial mailbox credentials in the dedicated
+"NextSnapMail" section of their personal settings.
 	]]></description>
 	<namespace>NextSnapMail</namespace>
 	<documentation>
 		<user>https://github.com/oe79/NextSnapMail/blob/master/integrations/nextcloud/nextsnapmail/README.md</user>
-		<admin>https://github.com/the-djmaze/snappymail/wiki/Admin-Manual</admin>
-		<developer>https://github.com/the-djmaze/snappymail/wiki/Developer-Documentation</developer>
-		<website>https://github.com/the-djmaze/snappymail/wiki</website>
+		<admin>https://github.com/oe79/NextSnapMail/blob/master/integrations/nextcloud/nextsnapmail/README.md</admin>
+		<developer>https://github.com/oe79/NextSnapMail</developer>
+		<website>https://github.com/oe79/NextSnapMail</website>
 	</documentation>
 	<category>integration</category>
 	<category>office</category>
 	<category>search</category>
 	<category>social</category>
-	<screenshot>https://raw.githubusercontent.com/the-djmaze/snappymail/master/integrations/nextcloud/screenshots/inbox.jpg</screenshot>
 	<website>https://github.com/oe79/NextSnapMail</website>
 	<discussion>https://github.com/oe79/NextSnapMail/discussions</discussion>
 	<repository>https://github.com/oe79/NextSnapMail</repository>


### PR DESCRIPTION
## Summary
- Update the Nextcloud app metadata to point to NextSnapMail documentation and repository links
- Remove inherited upstream screenshot metadata until project-specific screenshots are available
- Refresh the Nextcloud integration README for the standalone NextSnapMail app and dedicated settings sections

## Validation
- Parsed appinfo/info.xml
- git diff --check