### PR TITLE
Add Nextcloud app store release tooling

### DIFF
--- a/build/nextcloud-release.php
+++ b/build/nextcloud-release.php
@@ -1,0 +1,344 @@
+#!/usr/bin/env php
+<?php
+
+define('ROOT_DIR', dirname(__DIR__));
+chdir(ROOT_DIR);
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+$options = getopt('', [
+	'source::',
+	'destination::',
+	'cert-dir::',
+	'sign',
+	'help'
+]);
+
+if (isset($options['help'])) {
+	echo "Build a cleaned NextSnapMail package for the Nextcloud App Store.\n\n";
+	echo "Usage:\n";
+	echo "  php build/nextcloud-release.php [--source=PATH] [--destination=PATH] [--sign] [--cert-dir=PATH]\n\n";
+	echo "Defaults:\n";
+	echo "  --source       build/local-nextsnapmail-app/nextsnapmail\n";
+	echo "  --destination  build/dist/nextcloud/<version>\n";
+	echo "  --cert-dir     ~/.nextcloud/certificates\n\n";
+	echo "The --sign option requires nextsnapmail.crt and nextsnapmail.key in the certificate directory.\n";
+	exit(0);
+}
+
+$appId = 'nextsnapmail';
+$package = json_decode(file_get_contents(ROOT_DIR . '/package.json'));
+if (!$package || empty($package->version)) {
+	fail('Could not read package version from package.json');
+}
+
+$version = $package->version;
+$source = normalizePath($options['source'] ?? 'build/local-nextsnapmail-app/nextsnapmail');
+$destination = normalizePath($options['destination'] ?? "build/dist/nextcloud/{$version}");
+$certDir = normalizePath($options['cert-dir'] ?? defaultCertificateDirectory());
+$sign = isset($options['sign']);
+
+$stagingRoot = normalizePath("build/tmp/nextcloud-release");
+$stagingApp = "{$stagingRoot}/{$appId}";
+
+if (!is_dir($source)) {
+	fail("Source app directory does not exist: {$source}");
+}
+
+cleanDirectory($stagingRoot);
+mkdir($stagingRoot, 0777, true);
+copyDirectory($source, $stagingApp);
+syncRepositoryMetadata($stagingApp, $version);
+
+validateStagedApp($stagingApp, $appId, $version);
+
+if ($sign) {
+	addNextcloudSignature($stagingApp, $appId, $certDir);
+	validateStagedApp($stagingApp, $appId, $version, true);
+}
+
+is_dir($destination) || mkdir($destination, 0777, true);
+
+$archiveBase = "{$appId}-{$version}-nextcloud" . ($sign ? '' : '-unsigned');
+$gzPath = "{$destination}/{$archiveBase}.tar.gz";
+
+@unlink($gzPath);
+
+createTarGz($stagingRoot, $appId, $gzPath);
+
+$archiveHash = hash_file('sha512', $gzPath);
+
+echo "Created {$gzPath}\n";
+echo "SHA512 {$archiveHash}\n";
+echo $sign ? "Package is signed with appinfo/signature.json\n" : "Package is unsigned; rerun with --sign after the certificate is available\n";
+
+function defaultCertificateDirectory(): string
+{
+	$home = getenv('HOME') ?: getenv('USERPROFILE');
+	if (!$home) {
+		return '.nextcloud/certificates';
+	}
+
+	return rtrim(str_replace('\\', '/', $home), '/') . '/.nextcloud/certificates';
+}
+
+function normalizePath(string $path): string
+{
+	$path = str_replace('\\', '/', $path);
+	if (preg_match('/^[A-Za-z]:\//', $path) || str_starts_with($path, '/')) {
+		return rtrim($path, '/');
+	}
+
+	return rtrim(str_replace('\\', '/', ROOT_DIR . '/' . $path), '/');
+}
+
+function fail(string $message): void
+{
+	fwrite(STDERR, "Error: {$message}\n");
+	exit(1);
+}
+
+function cleanDirectory(string $directory): void
+{
+	$directory = normalizePath($directory);
+	$allowedRoot = normalizePath('build/tmp');
+
+	if (!str_starts_with($directory, $allowedRoot . '/')) {
+		fail("Refusing to clean directory outside build/tmp: {$directory}");
+	}
+
+	if (!is_dir($directory)) {
+		return;
+	}
+
+	$items = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+
+	foreach ($items as $item) {
+		$item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+	}
+
+	rmdir($directory);
+}
+
+function copyDirectory(string $source, string $destination): void
+{
+	$source = normalizePath($source);
+	$destination = normalizePath($destination);
+
+	$sourceLength = strlen($source) + 1;
+	$items = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($source, FilesystemIterator::SKIP_DOTS),
+		RecursiveIteratorIterator::SELF_FIRST
+	);
+
+	mkdir($destination, 0777, true);
+
+	foreach ($items as $item) {
+		$relative = str_replace('\\', '/', substr($item->getPathname(), $sourceLength));
+		if (shouldExclude($relative)) {
+			continue;
+		}
+
+		$target = "{$destination}/{$relative}";
+		if ($item->isDir()) {
+			is_dir($target) || mkdir($target, 0777, true);
+		} else {
+			is_dir(dirname($target)) || mkdir(dirname($target), 0777, true);
+			copy($item->getPathname(), $target);
+		}
+	}
+}
+
+function syncRepositoryMetadata(string $appPath, string $version): void
+{
+	copy(ROOT_DIR . '/CHANGELOG.md', "{$appPath}/CHANGELOG.md");
+	file_put_contents("{$appPath}/VERSION", $version . "\n");
+}
+
+function shouldExclude(string $relativePath): bool
+{
+	$relativePath = str_replace('\\', '/', $relativePath);
+	$basename = basename($relativePath);
+
+	if ($basename === '.DS_Store' || $basename === 'Thumbs.db') {
+		return true;
+	}
+
+	if ($basename === 'signature.json') {
+		return true;
+	}
+
+	if (str_starts_with($relativePath, '.git/') || str_starts_with($relativePath, '.github/')) {
+		return true;
+	}
+
+	if (preg_match('/\.(bak|old)$/i', $basename)) {
+		return true;
+	}
+
+	return false;
+}
+
+function validateStagedApp(string $appPath, string $appId, string $version, bool $expectSignature = false): void
+{
+	$requiredFiles = [
+		'appinfo/info.xml',
+		'app/index.php',
+		'app/README.md',
+		'README.md',
+		'CHANGELOG.md',
+		'app/bundled-plugins/nextcloud/index.php'
+	];
+
+	foreach ($requiredFiles as $file) {
+		if (!is_file("{$appPath}/{$file}")) {
+			fail("Required file is missing from package: {$file}");
+		}
+	}
+
+	$coreDirectories = glob("{$appPath}/app/snappymail/v/*", GLOB_ONLYDIR) ?: [];
+	if (!$coreDirectories) {
+		fail('Compiled SnappyMail core directory is missing below app/snappymail/v/');
+	}
+
+	$hasCompiledJavaScript = false;
+	foreach ($coreDirectories as $coreDirectory) {
+		if (is_file("{$coreDirectory}/static/js/min/app.min.js")) {
+			$hasCompiledJavaScript = true;
+			break;
+		}
+	}
+
+	if (!$hasCompiledJavaScript) {
+		fail('Compiled JavaScript is missing below app/snappymail/v/*/static/js/min/app.min.js');
+	}
+
+	$info = simplexml_load_file("{$appPath}/appinfo/info.xml");
+	if (!$info) {
+		fail('Could not parse appinfo/info.xml');
+	}
+
+	if ((string) $info->id !== $appId) {
+		fail("appinfo/info.xml has unexpected app id: {$info->id}");
+	}
+
+	if ((string) $info->version !== $version) {
+		fail("appinfo/info.xml has version {$info->version}, expected {$version}");
+	}
+
+	if ((string) $info->licence !== 'AGPL-3.0-only') {
+		fail("appinfo/info.xml has unexpected licence: {$info->licence}");
+	}
+
+	$signature = "{$appPath}/appinfo/signature.json";
+	if ($expectSignature && !is_file($signature)) {
+		fail('Signed package is missing appinfo/signature.json');
+	}
+
+	if (!$expectSignature && is_file($signature)) {
+		fail('Unsigned package unexpectedly contains appinfo/signature.json');
+	}
+
+	$items = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($appPath, FilesystemIterator::SKIP_DOTS)
+	);
+
+	foreach ($items as $item) {
+		$relative = str_replace('\\', '/', substr($item->getPathname(), strlen($appPath) + 1));
+		if ($expectSignature && $relative === 'appinfo/signature.json') {
+			continue;
+		}
+		if (shouldExclude($relative)) {
+			fail("Excluded file still exists in staging directory: {$relative}");
+		}
+	}
+}
+
+function addNextcloudSignature(string $appPath, string $appId, string $certDir): void
+{
+	$certFile = "{$certDir}/{$appId}.crt";
+	$keyFile = "{$certDir}/{$appId}.key";
+
+	if (!is_file($certFile)) {
+		fail("Certificate file is missing: {$certFile}");
+	}
+
+	if (!is_file($keyFile)) {
+		fail("Private key file is missing: {$keyFile}");
+	}
+
+	spl_autoload_register(function($name) {
+		$name = preg_replace('/^phpseclib\\\\/', '', $name);
+		$file = ROOT_DIR . '/build/phpseclib/' . str_replace('\\', '/', $name) . '.php';
+		if (is_file($file)) {
+			require $file;
+		}
+	});
+
+	$hashes = packageHashes($appPath);
+	ksort($hashes);
+
+	$cert = file_get_contents($certFile);
+	$rsa = new \phpseclib\Crypt\RSA();
+	$rsa->loadKey(file_get_contents($keyFile));
+
+	$x509 = new \phpseclib\File\X509();
+	$x509->loadX509($cert);
+	$x509->setPrivateKey($rsa);
+
+	$rsa->setSignatureMode(\phpseclib\Crypt\RSA::SIGNATURE_PSS);
+	$rsa->setMGFHash('sha512');
+	$rsa->setSaltLength(0);
+
+	$signature = $rsa->sign(json_encode($hashes));
+
+	file_put_contents("{$appPath}/appinfo/signature.json", json_encode([
+		'hashes' => $hashes,
+		'signature' => base64_encode($signature),
+		'certificate' => $cert
+	], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+}
+
+function packageHashes(string $appPath): array
+{
+	$hashes = [];
+	$items = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($appPath, FilesystemIterator::SKIP_DOTS)
+	);
+
+	foreach ($items as $item) {
+		if (!$item->isFile()) {
+			continue;
+		}
+
+		$relative = str_replace('\\', '/', substr($item->getPathname(), strlen($appPath) + 1));
+		if ($relative === 'appinfo/signature.json') {
+			continue;
+		}
+
+		$hashes[$relative] = hash_file('sha512', $item->getPathname());
+	}
+
+	return $hashes;
+}
+
+function createTarGz(string $stagingRoot, string $appId, string $gzPath): void
+{
+	$command = 'tar -czf '
+		. escapeshellarg($gzPath)
+		. ' -C '
+		. escapeshellarg($stagingRoot)
+		. ' '
+		. escapeshellarg($appId);
+
+	exec($command . ' 2>&1', $output, $exitCode);
+	if ($exitCode !== 0) {
+		fail("tar failed with exit code {$exitCode}:\n" . implode("\n", $output));
+	}
+
+	if (!is_file($gzPath)) {
+		fail("tar did not create expected archive: {$gzPath}");
+	}
+}

--- a/docs/app-store-release-checklist.md
+++ b/docs/app-store-release-checklist.md
@@ -1,0 +1,111 @@
+# NextSnapMail App Store release checklist
+
+This checklist tracks the preparation for publishing NextSnapMail as a
+standalone Nextcloud app.
+
+## App identity
+
+- App id: `nextsnapmail`
+- App name: `NextSnapMail`
+- Summary: `A SnappyMail fork focused on integration with Nextcloud`
+- Repository: <https://github.com/oe79/NextSnapMail>
+- Support/bugs: <https://github.com/oe79/NextSnapMail/issues>
+- Discussion: <https://github.com/oe79/NextSnapMail/discussions>
+- Licence: `AGPL-3.0-only`
+- Initial release version: `0.1.0`
+- Nextcloud compatibility: `20` through `34`
+
+## Positioning
+
+- Describe the app as an independent community fork of SnappyMail focused on
+  Nextcloud integration.
+- Do not describe the app as official, sponsored by, endorsed by, or affiliated
+  with Nextcloud GmbH.
+- Keep upstream attribution to SnappyMail and RainLoop.
+- Avoid reusing old upstream screenshots for the App Store entry. Use own
+  screenshots from a NextSnapMail installation.
+
+## Package requirements
+
+- Build package root must be `nextsnapmail/`.
+- Package must include `nextsnapmail/appinfo/info.xml`.
+- Package must include the compiled SnappyMail core under
+  `nextsnapmail/app/snappymail/v/<core-version>/` (currently `2.38.2`).
+- Package must include bundled extensions under
+  `nextsnapmail/app/bundled-plugins/`.
+- Package must not include local backup files such as `*.old` or `*.bak`.
+- Unsigned test packages must not include `appinfo/signature.json`.
+- Final App Store packages must include a valid `appinfo/signature.json`.
+
+## Local package build
+
+Prepare or update the local app directory first:
+
+```bash
+build/local-nextsnapmail-app/nextsnapmail
+```
+
+Create an unsigned package for local structure checks:
+
+```bash
+php build/nextcloud-release.php
+```
+
+Expected output:
+
+```bash
+build/dist/nextcloud/0.1.0/nextsnapmail-0.1.0-nextcloud-unsigned.tar.gz
+```
+
+After the Nextcloud certificate has been issued, save it as:
+
+```bash
+~/.nextcloud/certificates/nextsnapmail.crt
+```
+
+The private key must stay local and must not be committed:
+
+```bash
+~/.nextcloud/certificates/nextsnapmail.key
+```
+
+Create the signed App Store package:
+
+```bash
+php build/nextcloud-release.php --sign
+```
+
+Expected output:
+
+```bash
+build/dist/nextcloud/0.1.0/nextsnapmail-0.1.0-nextcloud.tar.gz
+```
+
+## App Store submission fields
+
+- Name: `NextSnapMail`
+- Short description:
+  `A SnappyMail fork focused on integration with Nextcloud`
+- Longer description:
+  Use the description from `integrations/nextcloud/nextsnapmail/appinfo/info.xml`
+  and keep the independent community fork disclaimer.
+- Categories:
+  - Integration
+  - Office
+  - Search
+- Screenshots:
+  - NextSnapMail loading/login view
+  - NextSnapMail personal settings section
+  - NextSnapMail admin settings section
+  - Mailbox view inside Nextcloud
+- Release notes:
+  Use the `0.1.0` section from `CHANGELOG.md`.
+
+## Before publishing
+
+- Certificate request is merged by Nextcloud.
+- `nextsnapmail.crt` is saved locally next to `nextsnapmail.key`.
+- Signed package has been created with `php build/nextcloud-release.php --sign`.
+- Package has been tested on a fresh Nextcloud installation.
+- GitHub release `v0.1.0` exists and contains the signed `.tar.gz`.
+- App Store entry points to the GitHub release artifact.


### PR DESCRIPTION
## Summary
- add a dedicated Nextcloud App Store package builder for NextSnapMail
- document App Store release requirements and submission fields
- support unsigned package checks and signed package creation once a certificate is available

## Tests
- php -l build/nextcloud-release.php
- php build/nextcloud-release.php
- php build/nextcloud-release.php --sign
- verified package structure and signature metadata