### PR TITLE
Prepare NextSnapMail 0.1.1 metadata fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.1.1 – 2026-07-01
+
+### Fixed
+
+- Ensure the Nextcloud App Store release package uses the cleaned NextSnapMail
+  app metadata from the repository instead of stale local test metadata.
+
+
 ## 0.1.0 – 2026-06-30
 
 Initial NextSnapMail release as an independent SnappyMail fork focused on

--- a/build/nextcloud-release.php
+++ b/build/nextcloud-release.php
@@ -153,6 +153,11 @@ function copyDirectory(string $source, string $destination): void
 
 function syncRepositoryMetadata(string $appPath, string $version): void
 {
+	copy(ROOT_DIR . '/integrations/nextcloud/nextsnapmail/appinfo/info.xml', "{$appPath}/appinfo/info.xml");
+	$infoXml = file_get_contents("{$appPath}/appinfo/info.xml");
+	$infoXml = preg_replace('/<version>[^<]*<\/version>/', "<version>{$version}</version>", $infoXml);
+	file_put_contents("{$appPath}/appinfo/info.xml", $infoXml);
+
 	copy(ROOT_DIR . '/CHANGELOG.md', "{$appPath}/CHANGELOG.md");
 	file_put_contents("{$appPath}/VERSION", $version . "\n");
 }

--- a/integrations/nextcloud/nextsnapmail/appinfo/info.xml
+++ b/integrations/nextcloud/nextsnapmail/appinfo/info.xml
@@ -5,7 +5,13 @@
 	<summary>A SnappyMail fork focused on integration with Nextcloud</summary>
 	<version>0.1.0</version>
 	<licence>AGPL-3.0-only</licence>
-	<author>SnappyMail, RainLoop Team, Nextgen-Networks, Tab Fitts, Nathan Kinkade, Pierre-Alain Bandinelli</author>
+	<author homepage="https://github.com/oe79">Erhard Scharf</author>
+	<author homepage="https://github.com/the-djmaze/snappymail">SnappyMail contributors</author>
+	<author>RainLoop Team</author>
+	<author>Nextgen-Networks</author>
+	<author>Tab Fitts</author>
+	<author>Nathan Kinkade</author>
+	<author>Pierre-Alain Bandinelli</author>
 	<description><![CDATA[**A SnappyMail fork focused on integration with Nextcloud.**
 
 NextSnapMail is an independent community fork of SnappyMail for the Nextcloud

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "NextSnapMail",
   "description": "A SnappyMail fork focused on integration with Nextcloud",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/oe79/NextSnapMail",
   "author": {
     "name": "NextSnapMail contributors",


### PR DESCRIPTION
## Summary
- bump NextSnapMail to 0.1.1
- add Erhard Scharf as the NextSnapMail maintainer/author while preserving upstream attribution
- ensure release packages use the cleaned repository appinfo metadata instead of stale local test metadata

## Tests
- php -l build/nextcloud-release.php
- php build/nextcloud-release.php --sign
- inspected packaged appinfo/info.xml and appinfo/signature.json