### PR TITLE
Prepare NextSnapMail 0.1.2 disclaimer and admin title update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.1.2 – 2026-07-02
+
+### Changed
+
+- Add an explicit App Store disclaimer that NextSnapMail is provided as-is and
+  should be used at the user's own risk.
+- Show `NextSnapMail` instead of `SnappyMail` in the embedded admin panel
+  header.
+
+
 ## 0.1.1 – 2026-07-01
 
 ### Fixed

--- a/integrations/nextcloud/nextsnapmail/appinfo/info.xml
+++ b/integrations/nextcloud/nextsnapmail/appinfo/info.xml
@@ -17,6 +17,10 @@
 NextSnapMail is an independent community fork of SnappyMail for the Nextcloud
 use case. It is not affiliated with, endorsed by, or sponsored by Nextcloud GmbH.
 
+NextSnapMail is under active development and provided as-is. Please test it
+carefully before using it in production. Installation and use are at your own
+risk.
+
 **Lightweight & fast email client.**
 
 - **Dark mode**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "NextSnapMail",
   "description": "A SnappyMail fork focused on integration with Nextcloud",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/oe79/NextSnapMail",
   "author": {
     "name": "NextSnapMail contributors",

--- a/snappymail/v/0.0.0/app/templates/Views/Admin/AdminPane.html
+++ b/snappymail/v/0.0.0/app/templates/Views/Admin/AdminPane.html
@@ -1,5 +1,5 @@
 <div class="b-toolbar g-ui-user-select-none">
 	<a class="btn btn-thin fontastic toggleLeft" data-bind="click: toggleLeftPanel"></a>
-	<h4>SnappyMail - <span data-i18n="TOP_PANEL/LABEL_ADMIN_PANEL"></span></h4>
+	<h4>NextSnapMail - <span data-i18n="TOP_PANEL/LABEL_ADMIN_PANEL"></span></h4>
 	<a class="btn btn-logout fontastic" data-bind="click: logoutClick">⏻</a>
 </div>


### PR DESCRIPTION
## Summary
- add an explicit as-is / own-risk disclaimer to the App Store description
- show NextSnapMail instead of SnappyMail in the embedded admin panel header
- bump version to 0.1.2

## Tests
- php -l build/nextcloud-release.php
- php build/nextcloud-release.php --sign
- inspected packaged appinfo/info.xml, AdminPane.html and appinfo/signature.json